### PR TITLE
make encoding explicit to fix unicode rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ instance of this yourself)
 * [mistune](https://pypi.python.org/pypi/mistune)
 * [inflect](https://pypi.python.org/pypi/inflect)
 * [six](https://pypi.python.org/pypi/six)
+* [colorama](https://pypi.python.org/pypi/colorama)
+* [feedgen](https://pypi.python.org/pypi/feedgen)
 
 ### contributing
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'inflect',
         'mistune',
         'colorama',
-        'six'
+        'six',
+        'feedgen',
     ],
     include_package_data = True,
     entry_points = {

--- a/ttbp/atom.py
+++ b/ttbp/atom.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+
+'''
+ttbp: tilde town blogging platform
+(also known as the feels engine)
+a console-based blogging program developed for tilde.town
+copyright (c) 2016 ~endorphant (endorphant@tilde.town)
+
+atom.py:
+Atom feed generation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+the complete codebase is available at:
+https://github.com/modgethanc/ttbp
+'''
+from . import config
+from . import util
+from feedgen.feed import FeedGenerator
+import os
+import mistune
+import datetime
+
+def publish_atom(entry_filenames, settings):
+    fg = FeedGenerator()
+    url = (config.LIVE + config.USER + '/' +
+           str(settings.get("publish dir"))).rstrip('/')
+    fg.id(url)
+    fg.title("{}'s feels".format(config.USER))
+    fg.author(name=config.USER)
+    fg.link(href=url+'/', rel='alternate')
+    fg.link(href=url+'/atom.xml', rel='self')
+    fg.language('en') # TODO: feels language should be configurable
+
+    for filename in entry_filenames:
+        date = util.parse_date(filename)
+        title = "-".join(date)
+        name = "".join(date)
+
+        path = os.path.join(config.MAIN_FEELS, filename)
+        with open(path) as f:
+            raw = f.read()
+        html = mistune.markdown(raw)
+
+        fe = fg.add_entry()
+        fe.id(url+'/'+name)
+        fe.link(href=url+'/'+name+'.html', rel="alternate")
+        fe.title(title)
+        fe.author(name=config.USER)
+        fe.content(html, type="html")
+        try: # crashing because of an invalid date would be sad
+            year, month, day = [int(x) for x in date]
+            dt = datetime.datetime(year, month, day)
+            fe.updated(dt)
+        except ValueError:
+            pass
+    outfile = os.path.join(config.WWW, 'atom.xml')
+    fg.atom_file(outfile)
+
+def select_atom():
+    publish = util.input_yn("""
+SETTING UP ATOM
+
+Atom is a syndication format similar to RSS.
+it is used so that people can subscribe to blogs and other news sources.
+
+do you want to generate an atom feed for your feels along the HTML?
+this setting only has effect if publishing is enabled.
+
+you can change this option any time.
+""")
+    return publish

--- a/ttbp/config/defaults/header.txt
+++ b/ttbp/config/defaults/header.txt
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
   <head>
+    <meta charset="utf-8">
     <title>$USER on TTBP</title>
     <link rel="stylesheet" href="style.css" />
   </head>

--- a/ttbp/core.py
+++ b/ttbp/core.py
@@ -43,6 +43,7 @@ from . import chatter
 from . import config
 from . import gopher
 from . import util
+from . import atom
 
 FEED = os.path.join("/home", "endorphant", "public_html", "ttbp", "index.html")
 SETTINGS = {}
@@ -95,6 +96,23 @@ def get_files(feelsdir=config.MAIN_FEELS):
 
     return files
 
+def render(files):
+    out = ""
+    if publishing():
+        write_html("index.html")
+        out += "posted to {url}/index.html\n\n> ".format(
+            url="/".join(
+                [config.LIVE+config.USER,
+                    str(SETTINGS.get("publish dir"))]))
+        if SETTINGS.get('gopher'):
+            gopher.publish_gopher('feels', files)
+            out += "also posted to your ~/public_gopher!\n\n> "
+        if SETTINGS.get('atom'):
+            atom.publish_atom(files, SETTINGS)
+            out += "also posted to your atom feed {url}/atom.xml!\n\n> "
+    return out
+
+
 def load_files(feelsdir=config.MAIN_FEELS):
     '''
     file loader
@@ -108,11 +126,7 @@ def load_files(feelsdir=config.MAIN_FEELS):
 
     load_nopubs()
     FILES = get_files(feelsdir)
-
-    if publishing():
-        write_html("index.html")
-        if SETTINGS.get('gopher'):
-            gopher.publish_gopher('feels', FILES)
+    render(FILES)
 
 def load_nopubs():
     """Load a list of the user's nopub entries.

--- a/ttbp/ttbp.py
+++ b/ttbp/ttbp.py
@@ -50,6 +50,7 @@ from . import core
 from . import chatter
 from . import gopher
 from . import util
+from . import atom
 
 __version__ = "0.12.2"
 __author__ = "endorphant <endorphant@tilde.town)"
@@ -75,6 +76,7 @@ DEFAULT_SETTINGS = {
         "publishing": False,
         "rainbows": False,
         "post as nopub": False,
+        "atom": False,
     }
 
 ## user globals
@@ -85,7 +87,8 @@ SETTINGS = {
         "publishing": False,
         "rainbows": False,
         "post as nopub": False,
-        }
+        "atom": False,
+    }
 
 ## ttbp specific utilities
 
@@ -402,7 +405,8 @@ def setup_repair():
             "publish dir": select_publish_dir,
             "gopher": gopher.select_gopher,
             "rainbows": toggle_rainbows,
-            "post as nopub": toggle_pub_default
+            "post as nopub": toggle_pub_default,
+            "atom": atom.select_atom,
             }
 
     for option in iter(settings_map):
@@ -501,6 +505,13 @@ def setup():
         elif settingList[int(choice)] == "post as nopub":
             SETTINGS.update({"post as nopub": toggle_pub_default()})
             redraw("posting default set to {nopub}".format(nopub=SETTINGS.get("post as nopub")))
+            save_settings()
+            return setup()
+
+        #atom opt-in
+        elif settingList[int(choice)] == "atom":
+            SETTINGS.update({"atom": atom.select_atom()})
+            redraw("atom set to {}".format(SETTINGS.get("atom")))
             save_settings()
             return setup()
 
@@ -1202,16 +1213,7 @@ def write_entry(entry=os.path.join(config.MAIN_FEELS, "test.txt")):
     if SETTINGS.get("post as nopub"):
         core.toggle_nopub(os.path.basename(entry))
     else:
-        if core.publishing():
-            core.write_html("index.html")
-            left = "posted to {url}/index.html\n\n> ".format(
-                url="/".join(
-                    [config.LIVE+config.USER,
-                        str(SETTINGS.get("publish dir"))]))
-
-        if SETTINGS.get('gopher'):
-            gopher.publish_gopher('feels', core.FILES)
-            left += "also posted to your ~/public_gopher!\n\n> "
+        left = core.render(core.FILES)
 
     #core.load_files()
     redraw(left + "thanks for sharing your feels!")


### PR DESCRIPTION
Without this, browers turn á into Ã¡ (because they think blogs are latin1 or whatever).